### PR TITLE
Let the user decide the Zookeeper 'server.1'

### DIFF
--- a/src/usr/local/sbin/start.sh
+++ b/src/usr/local/sbin/start.sh
@@ -40,14 +40,11 @@ do
   if [[ $VAR =~ ^ZOOKEEPER_SERVER_[0-9]+= ]]; then
     SERVER_ID=`echo "$VAR" | sed -r "s/ZOOKEEPER_SERVER_(.*)=.*/\1/"`
     SERVER_IP=`echo "$VAR" | sed 's/.*=//'`
-    if [ "${SERVER_ID}" = "${ZOOKEEPER_ID}" ]; then
-      echo "server.${SERVER_ID}=0.0.0.0:2888:3888" >> /opt/zookeeper/conf/zoo.cfg
-      echo "server.${SERVER_ID}=0.0.0.0:2888:3888"
-    else
-      echo "server.${SERVER_ID}=${SERVER_IP}:2888:3888" >> /opt/zookeeper/conf/zoo.cfg
-      echo "server.${SERVER_ID}=${SERVER_IP}:2888:3888"
-    fi
+
+    echo "server.${SERVER_ID}=${SERVER_IP}:2888:3888" >> /opt/zookeeper/conf/zoo.cfg
+    echo "server.${SERVER_ID}=${SERVER_IP}:2888:3888"
   fi
+
 done
 
 su zookeeper -s /bin/bash -c "/opt/zookeeper/bin/zkServer.sh start-foreground"


### PR DESCRIPTION
The lines remove in this commit were ALWAYS adding `server.1` as `0.0.0.0:2888:3888`. There can be cases where this should be configurable.
E.g: If a Zookeeper deployment in Kubernetes or somewhere else is exposed using a Load Balancer, then the user would wanna give the Load Balancer's IP as `server.1` instead of `0.0.0.0`

Signed-off-by: Amit Yadav <amityadavk2@gmail.com>